### PR TITLE
Add a command to list the plugins already installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ asdf plugin-add <name> <git-url>
 # asdf plugin-add erlang https://github.com/HashNuke/asdf-erlang.git
 ```
 
+##### List installed plugins
+
+```bash
+asdf plugin-list
+# asdf plugin-list
+```
+
 ##### Remove a plugin
 
 ```bash

--- a/bin/asdf
+++ b/bin/asdf
@@ -11,6 +11,7 @@ source $(dirname $(dirname $0))/lib/commands/list.sh
 source $(dirname $(dirname $0))/lib/commands/list-all.sh
 source $(dirname $(dirname $0))/lib/commands/reshim.sh
 source $(dirname $(dirname $0))/lib/commands/plugin-add.sh
+source $(dirname $(dirname $0))/lib/commands/plugin-list.sh
 source $(dirname $(dirname $0))/lib/commands/plugin-update.sh
 source $(dirname $(dirname $0))/lib/commands/plugin-remove.sh
 
@@ -53,6 +54,9 @@ case $1 in
 
 "plugin-add")
     plugin_add_command $callback_args;;
+
+"plugin-list")
+    plugin_list_command $callback_args;;
 
 "plugin-update")
     plugin_update_command $callback_args;;

--- a/help.txt
+++ b/help.txt
@@ -1,5 +1,6 @@
 MANAGE PLUGINS
   asdf plugin-add <name> <git-url>     Add git repo as plugin
+  asdf plugin-list                     List installed plugin
   asdf plugin-remove <name>            Remove plugin and package versions
   asdf plugin-update <name>            Update plugin
   asdf plugin-update --all             Update all plugins

--- a/lib/commands/plugin-list.sh
+++ b/lib/commands/plugin-list.sh
@@ -6,6 +6,6 @@ plugin_list_command() {
       echo "* $(basename $plugin_path)"
     done
   else
-    echo 'Oohes nooes ~! No versions installed'
+    echo 'Oohes nooes ~! No plugins installed'
   fi
 }

--- a/lib/commands/plugin-list.sh
+++ b/lib/commands/plugin-list.sh
@@ -1,0 +1,11 @@
+plugin_list_command() {
+  local plugins_path=$(get_plugin_path)
+
+  if ls $plugins_path &> /dev/null; then
+    for plugin_path in $plugins_path/* ; do
+      echo "* $(basename $plugin_path)"
+    done
+  else
+    echo 'Oohes nooes ~! No versions installed'
+  fi
+}


### PR DESCRIPTION
This command could be useful when, for example, you have a setup script and want to know if you need to install the plugin or if the plugin is already installed on the machine.