### PR TITLE
Add check to ensure current "file" in loop is actually and executable file

### DIFF
--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -108,7 +108,6 @@ generate_shims_for_version() {
   IFS=' ' read -a all_bin_paths <<< "$space_seperated_list_of_bin_paths"
 
   for bin_path in "${all_bin_paths[@]}"; do
-    #TODO check if it's actually an executable file
     for executable_file in $install_path/$bin_path/*; do
       # because just $executable_file gives absolute path; We don't want version hardcoded in shim
       local executable_path_relative_to_install_path=$bin_path/$(basename $executable_file)

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -111,7 +111,6 @@ generate_shims_for_version() {
     for executable_file in $install_path/$bin_path/*; do
       # because just $executable_file gives absolute path; We don't want version hardcoded in shim
       local executable_path_relative_to_install_path=$bin_path/$(basename $executable_file)
-      write_shim_script $plugin_name $executable_path_relative_to_install_path
       if [ -x $executable_path_relative_to_install_path ]; then
           write_shim_script $plugin_name $executable_path_relative_to_install_path
       fi

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -113,6 +113,9 @@ generate_shims_for_version() {
       # because just $executable_file gives absolute path; We don't want version hardcoded in shim
       local executable_path_relative_to_install_path=$bin_path/$(basename $executable_file)
       write_shim_script $plugin_name $executable_path_relative_to_install_path
+      if [ -x $executable_path_relative_to_install_path ]; then
+          write_shim_script $plugin_name $executable_path_relative_to_install_path
+      fi
     done
   done
 }


### PR DESCRIPTION
This works most of the time, but when the directory does not contain any files `$install_path/$bin_path/*` doesn't expand (e.g. it might look like `"~/.asdf/install/lua/lua-empty-bin-dir/*"` for a Lua install). As a result what is passed to `write_shim_script` is passed a non-existent file and this causes the function to fail.  With this check, we ensure the file exists and is an executable. This ensures we are only creating shims for real executable files.