### PR TITLE
Add more details to the 'asdf install' command help and the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ The versions can be in the following format:
 * `ref:v1.0.2-a` or `ref:39cb398vb39` - tag/commit/branch to download from github and compile
 * `path:/src/elixir` - a path to custom compiled version of a tool to use. For use by language developers and such.
 
+To install all the tools defined in a `.tool-versions` file run the `asdf install` command with no other arguments in the directory containing the `.tool-versions` file.
+
 ## Credits
 
 Me ([@HashNuke](http://github.com/HashNuke)), High-fever, cold, cough.

--- a/help.txt
+++ b/help.txt
@@ -7,7 +7,9 @@ MANAGE PLUGINS
 
 
 MANAGE PACKAGES
-  asdf install <name> <version>        Install a specific version of a package
+  asdf install <name> <version>        Install a specific version of a package or,
+                                       with no arguments, install all the package
+                                       versions listed in the .tool-versions file
   asdf uninstall <name> <version>      Remove a specific version of a package
   asdf which <name>                    Display version set or being used for package
   asdf where <name> <version>          Display install path for an installed version


### PR DESCRIPTION
I wasn't aware of how the `asdf install` command worked when invoked with no arguments. Hopefully these additions will make it clear that it can install packages listed in the .tool-versions file.