### PR TITLE
Adds (very) basic zsh autocompletion

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -8,3 +8,9 @@ fi
 
 asdf_dir=$(cd $(dirname $current_script_path); echo $(pwd))
 export PATH="${asdf_dir}/bin:${asdf_dir}/shims:$PATH"
+
+if [ -n "$ZSH_VERSION" ]; then
+  fpath=(${asdf_dir}/completions $fpath)
+  autoload -U compinit
+  compinit
+fi

--- a/completions/_asdf
+++ b/completions/_asdf
@@ -1,0 +1,3 @@
+#compdef asdf
+
+_arguments "1: :(plugin-add plugin-list plugin-remove plugin-update install uninstall which where list list-all reshim)"


### PR DESCRIPTION
Only top level commands are supported i.e. `asdf <TAB>`

and you get a list of asdf commands. That's it.